### PR TITLE
feat: Add support for credential providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,17 @@ Add the following to your Prism configuration (`config/prism.php`):
 
 ```php
 'bedrock' => [ // Key should match Bedrock::KEY
-    'api_key' => env('AWS_ACCESS_KEY_ID'),
-    'api_secret' => env('AWS_SECRET_ACCESS_KEY'),
-    'session_token' => env('AWS_SESSION_TOKEN'), // Optional
-    'use_default_credential_provider' => env('AWS_USE_DEFAULT_CREDENTIAL_PROVIDER', false),
     'region' => env('AWS_REGION', 'us-east-1')
+
+    // Set to true to ignore other auth configuration and use the AWS SDK default credential chain
+    // read more at https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_default_chain.html
+    'use_default_credential_provider' => env('AWS_USE_DEFAULT_CREDENTIAL_PROVIDER', false), 
+
+    'api_key' => env('AWS_ACCESS_KEY_ID'), //  Ignored with `use_default_credential_provider` === true
+    'api_secret' => env('AWS_SECRET_ACCESS_KEY'), //  Ignored with `use_default_credential_provider` === true
+    'session_token' => env('AWS_SESSION_TOKEN'), // Only required for temporary credentials. Ignored with `use_default_credential_provider` === true
 ],
 ```
-
-Enable `use_default_credential_provider` if you want to use the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_default_chain.html) which 
-checks multiple locations for credentials.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,14 @@ Add the following to your Prism configuration (`config/prism.php`):
 'bedrock' => [ // Key should match Bedrock::KEY
     'api_key' => env('AWS_ACCESS_KEY_ID'),
     'api_secret' => env('AWS_SECRET_ACCESS_KEY'),
+    'session_token' => env('AWS_SESSION_TOKEN'), // Optional
+    'use_default_credential_provider' => env('AWS_USE_DEFAULT_CREDENTIAL_PROVIDER', false),
     'region' => env('AWS_REGION', 'us-east-1')
 ],
 ```
+
+Enable `use_default_credential_provider` if you want to use the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_default_chain.html) which 
+checks multiple locations for credentials.
 
 ## Usage
 

--- a/src/Bedrock.php
+++ b/src/Bedrock.php
@@ -24,8 +24,7 @@ class Bedrock implements Provider
     const KEY = 'bedrock';
 
     public function __construct(
-        #[\SensitiveParameter] protected string $apiKey,
-        #[\SensitiveParameter] protected string $apiSecret,
+        #[\SensitiveParameter] protected Credentials $credentials,
         protected string $region
     ) {}
 
@@ -141,10 +140,7 @@ class Bedrock implements Provider
 
                 $signature = new SignatureV4('bedrock', $this->region);
 
-                return $signature->signRequest($request, new Credentials(
-                    key: $this->apiKey,
-                    secret: $this->apiSecret
-                ));
+                return $signature->signRequest($request, $this->credentials);
             })
             ->throw();
     }

--- a/src/BedrockServiceProvider.php
+++ b/src/BedrockServiceProvider.php
@@ -13,6 +13,9 @@ class BedrockServiceProvider extends ServiceProvider
         $this->registerWithPrism();
     }
 
+    /**
+     * @param  array<string,mixed>  $config
+     */
     public static function getCredentials(array $config): Credentials
     {
         if ($config['use_default_credential_provider'] ?? false) {

--- a/src/BedrockServiceProvider.php
+++ b/src/BedrockServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Prism\Bedrock;
 
+use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\Credentials;
 use Illuminate\Support\ServiceProvider;
 
 class BedrockServiceProvider extends ServiceProvider
@@ -11,11 +13,25 @@ class BedrockServiceProvider extends ServiceProvider
         $this->registerWithPrism();
     }
 
+    public static function getCredentials(array $config): Credentials
+    {
+        if ($config['use_default_credential_provider'] ?? false) {
+            $provider = CredentialProvider::defaultProvider();
+        } else {
+            $provider = CredentialProvider::fromCredentials(new Credentials(
+                key: $config['api_key'],
+                secret: $config['api_secret'],
+                token: $config['session_token'] ?? null,
+            ));
+        }
+
+        return $provider()->wait();
+    }
+
     protected function registerWithPrism(): void
     {
         $this->app->get('prism-manager')->extend(Bedrock::KEY, fn ($app, $config): \Prism\Bedrock\Bedrock => new Bedrock(
-            apiKey: $config['api_key'],
-            apiSecret: $config['api_secret'],
+            credentials: BedrockServiceProvider::getCredentials($config),
             region: $config['region']
         ));
     }


### PR DESCRIPTION
## Description

Closes #1 

This uses the built-in logic in the AWS SDK for PHP to check multiple different ways of getting the AWS credentials. If the user provides an api key and secret in their config it will use those values otherwise it will use the default credential provider. If we want to make this new behavior opt-in we could add a new config value like `use_default_credential_provider` but for now it will use the default credential provider if the `api_key` and `api_secret` config values are null. I created a `getCredentials()` method in `BedrockServicProvider.php` to make it easy to override that method if needed.

For more information on credential providers see [Default credential provider chain](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_default_chain.html)

## Breaking Changes
The Bedrock class constructor arguments have changes. It now accepts a Credentials object instead of $apiKey and $apiSecret strings.
