### PR TITLE
chore: replace providerMeta with providerOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Prism Bedrock resolves the most appropriate API schema from the model string. If
 
 Therefore if you use a model that is not supported by AWS Bedrock Converse, and does not have a specific Prism Bedrock implementation, your request will fail.
 
-If you wish to force Prism Bedrock to use Converse instead of a vendor specific interface, you can do so with `withProviderMeta()`:
+If you wish to force Prism Bedrock to use Converse instead of a vendor specific interface, you can do so with `withProviderOptions()`:
 
 ```php
 use Prism\Prism\Prism;
@@ -146,7 +146,7 @@ use Prism\Bedrock\Enums\BedrockSchema;
 
 $response = Prism::text()
     ->using(Bedrock::KEY, 'anthropic.claude-3-sonnet-20240229-v1:0')
-    ->withProviderMeta(Bedrock::KEY, ['apiSchema' => BedrockSchema::Converse])
+    ->withProviderOptions(['apiSchema' => BedrockSchema::Converse])
     ->withPrompt('Explain quantum computing in simple terms')
     ->asText();
 
@@ -164,8 +164,8 @@ use Prism\Prism\ValueObjects\Messages\UserMessage;
 $response = Prism::text()
     ->using(Bedrock::KEY, 'anthropic.claude-3-sonnet-20240229-v1:0')
     ->withMessages([
-        (new UserMessage('Message with cache breakpoint'))->withProviderMeta('bedrock', ['cacheType' => 'ephemeral']),
-        (new UserMessage('Message with another cache breakpoint'))->withProviderMeta('bedrock', ['cacheType' => 'ephemeral']),
+        (new UserMessage('Message with cache breakpoint'))->withProviderOptions(['cacheType' => 'ephemeral']),
+        (new UserMessage('Message with another cache breakpoint'))->withProviderOptions(['cacheType' => 'ephemeral']),
         new UserMessage('Compare the last two messages.')
     ])
     ->asText();

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": "^8.3",
     "laravel/framework": "^11.0|^12.0",
     "aws/aws-sdk-php": "^3.339",
-    "prism-php/prism": ">=0.61.0"
+    "prism-php/prism": ">=0.63.0"
   },
   "config": {
     "allow-plugins": {

--- a/src/Bedrock.php
+++ b/src/Bedrock.php
@@ -105,9 +105,7 @@ class Bedrock implements Provider
 
     public function schema(PrismRequest $request): BedrockSchema
     {
-        $override = $request->providerMeta('bedrock');
-
-        $override = data_get($override, 'apiSchema', null);
+        $override = $request->providerOptions('apiSchema');
 
         return $override ?? BedrockSchema::fromModelString($request->model());
     }
@@ -127,7 +125,7 @@ class Bedrock implements Provider
 
         $enableCaching = $request instanceof EmbeddingRequest
             ? false
-            : $request->providerMeta('bedrock', 'enableCaching') ?? false;
+            : $request->providerOptions('enableCaching') ?? false;
 
         return Http::acceptJson()
             ->withHeader('explicitPromptCaching', $enableCaching ? 'enabled' : 'disabled')

--- a/src/Schemas/Anthropic/Maps/MessageMap.php
+++ b/src/Schemas/Anthropic/Maps/MessageMap.php
@@ -8,7 +8,6 @@ use BackedEnum;
 use Exception;
 use InvalidArgumentException;
 use Prism\Prism\Contracts\Message;
-use Prism\Prism\Enums\Provider;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Messages\Support\Image;
@@ -66,9 +65,7 @@ class MessageMap
      */
     protected static function mapSystemMessage(SystemMessage $systemMessage): array
     {
-        $providerMeta = array_merge($systemMessage->providerMeta('bedrock'), $systemMessage->providerMeta(Provider::Anthropic));
-
-        $cacheType = data_get($providerMeta, 'cacheType', null);
+        $cacheType = $systemMessage->providerOptions('cacheType');
 
         return array_filter([
             'type' => 'text',
@@ -97,9 +94,7 @@ class MessageMap
      */
     protected static function mapUserMessage(UserMessage $message): array
     {
-        $providerMeta = array_merge($message->providerMeta('bedrock'), $message->providerMeta(Provider::Anthropic));
-
-        $cacheType = data_get($providerMeta, 'cacheType', null);
+        $cacheType = $message->providerOptions('cacheType');
         $cache_control = $cacheType ? ['type' => $cacheType instanceof BackedEnum ? $cacheType->value : $cacheType] : null;
 
         if ($message->documents() !== []) {
@@ -124,9 +119,7 @@ class MessageMap
      */
     protected static function mapAssistantMessage(AssistantMessage $message): array
     {
-        $providerMeta = array_merge($message->providerMeta('bedrock'), $message->providerMeta(Provider::Anthropic));
-
-        $cacheType = data_get($providerMeta, 'cacheType', null);
+        $cacheType = $message->providerOptions('cacheType');
 
         $content = [];
 

--- a/src/Schemas/Anthropic/Maps/ToolMap.php
+++ b/src/Schemas/Anthropic/Maps/ToolMap.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Prism\Bedrock\Schemas\Anthropic\Maps;
 
-use Prism\Prism\Enums\Provider;
 use Prism\Prism\Tool as PrismTool;
 use UnitEnum;
 
@@ -17,7 +16,7 @@ class ToolMap
     public static function map(array $tools): array
     {
         return array_map(function (PrismTool $tool): array {
-            $cacheType = data_get($tool->providerMeta(Provider::Anthropic), 'cacheType', null);
+            $cacheType = $tool->providerOptions('cacheType');
 
             return array_filter([
                 'name' => $tool->name(),

--- a/src/Schemas/Converse/Maps/MessageMap.php
+++ b/src/Schemas/Converse/Maps/MessageMap.php
@@ -47,7 +47,7 @@ class MessageMap
         foreach ($systemPrompts as $prompt) {
             $output[] = self::mapSystemMessage($prompt);
 
-            $cacheType = data_get($prompt->providerMeta('bedrock'), 'cacheType', null);
+            $cacheType = $prompt->providerOptions('cacheType');
 
             if ($cacheType) {
                 $output[] = ['cachePoint' => ['type' => $cacheType]];
@@ -105,7 +105,7 @@ class MessageMap
      */
     protected static function mapUserMessage(UserMessage $message): array
     {
-        $cacheType = data_get($message->providerMeta('bedrock'), 'cacheType', null);
+        $cacheType = $message->providerOptions('cacheType');
 
         return [
             'role' => 'user',
@@ -123,7 +123,7 @@ class MessageMap
      */
     protected static function mapAssistantMessage(AssistantMessage $message): array
     {
-        $cacheType = data_get($message->providerMeta('bedrock'), 'cacheType', null);
+        $cacheType = $message->providerOptions('cacheType');
 
         return [
             'role' => 'assistant',

--- a/tests/BedrockServiceProviderTest.php
+++ b/tests/BedrockServiceProviderTest.php
@@ -18,7 +18,7 @@ it('throws an exception for embeddings with Anthropic apiSchema', function (): v
 
     Prism::embeddings()
         ->using('bedrock', 'test-model')
-        ->withProviderMeta('bedrock', ['apiSchema' => BedrockSchema::Anthropic])
+        ->withProviderOptions(['apiSchema' => BedrockSchema::Anthropic])
         ->fromInput('Hello world')
         ->asEmbeddings();
 })->throws(PrismException::class, 'Prism Bedrock does not support embeddings for the anthropic apiSchema.');

--- a/tests/Schemas/Anthropic/AnthropicTextHandlerTest.php
+++ b/tests/Schemas/Anthropic/AnthropicTextHandlerTest.php
@@ -4,7 +4,6 @@ namespace Tests\Schemas\Anthropic;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Prism\Prism\Enums\Provider;
 use Prism\Prism\Facades\Tool;
 use Prism\Prism\Prism;
 use Prism\Prism\ValueObjects\Messages\Support\Image;
@@ -162,9 +161,9 @@ it('can calculate cache usage correctly', function (): void {
 
     $response = Prism::text()
         ->using('bedrock', 'anthropic.claude-3-5-haiku-20241022-v1:0')
-        ->withSystemPrompt(new SystemMessage('Old context'))->withProviderMeta(Provider::Anthropic, ['cacheType' => 'ephemeral'])
+        ->withSystemPrompt(new SystemMessage('Old context'))->withProviderOptions(['cacheType' => 'ephemeral'])
         ->withMessages([
-            (new UserMessage('New context'))->withProviderMeta(Provider::Anthropic, ['cacheType' => 'ephemeral']),
+            (new UserMessage('New context'))->withProviderOptions(['cacheType' => 'ephemeral']),
         ])
         ->asText();
 
@@ -188,7 +187,7 @@ it('enables prompt caching if the enableCaching provider meta is set on the requ
 
     Prism::text()
         ->using('bedrock', 'anthropic.claude-3-5-haiku-20241022-v1:0')
-        ->withProviderMeta('bedrock', ['enableCaching' => true])
+        ->withProviderOptions(['enableCaching' => true])
         ->withPrompt('Who are you?')
         ->asText();
 

--- a/tests/Schemas/Anthropic/Maps/MessageMapTest.php
+++ b/tests/Schemas/Anthropic/Maps/MessageMapTest.php
@@ -6,7 +6,6 @@ namespace Tests\Schemas\Anthropic\Maps;
 
 use InvalidArgumentException;
 use Prism\Bedrock\Schemas\Anthropic\Maps\MessageMap;
-use Prism\Prism\Enums\Provider;
 use Prism\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Messages\Support\Image;
@@ -160,7 +159,7 @@ it('maps system messages', function (): void {
 
 it('sets the cache type on a UserMessage if cacheType providerMeta is set on message', function (mixed $cacheType): void {
     expect(MessageMap::map([
-        (new UserMessage(content: 'Who are you?'))->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]),
+        (new UserMessage(content: 'Who are you?'))->withProviderOptions(['cacheType' => $cacheType]),
     ]))->toBe([[
         'role' => 'user',
         'content' => [
@@ -181,7 +180,7 @@ it('sets the cache type on a UserMessage image if cacheType providerMeta is set 
         (new UserMessage(
             content: 'Who are you?',
             additionalContent: [Image::fromPath('tests/Fixtures/test-image.png')]
-        ))->withProviderMeta(Provider::Anthropic, ['cacheType' => 'ephemeral']),
+        ))->withProviderOptions(['cacheType' => 'ephemeral']),
     ]))->toBe([[
         'role' => 'user',
         'content' => [
@@ -205,7 +204,7 @@ it('sets the cache type on a UserMessage image if cacheType providerMeta is set 
 
 it('sets the cache type on an AssistantMessage if cacheType providerMeta is set on message', function (mixed $cacheType): void {
     expect(MessageMap::map([
-        (new AssistantMessage(content: 'Who are you?'))->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]),
+        (new AssistantMessage(content: 'Who are you?'))->withProviderOptions(['cacheType' => $cacheType]),
     ]))->toBe([[
         'role' => 'assistant',
         'content' => [
@@ -223,7 +222,7 @@ it('sets the cache type on an AssistantMessage if cacheType providerMeta is set 
 
 it('sets the cache type on a SystemMessage if cacheType providerMeta is set on message', function (mixed $cacheType): void {
     expect(MessageMap::mapSystemMessages([
-        (new SystemMessage(content: 'Who are you?'))->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]),
+        (new SystemMessage(content: 'Who are you?'))->withProviderOptions(['cacheType' => $cacheType]),
     ]))->toBe([
         [
             'type' => 'text',

--- a/tests/Schemas/Anthropic/Maps/ToolMapTest.php
+++ b/tests/Schemas/Anthropic/Maps/ToolMapTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Schemas\Anthropic\Maps;
 
 use Prism\Bedrock\Schemas\Anthropic\Maps\ToolMap;
-use Prism\Prism\Enums\Provider;
 use Prism\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
 use Prism\Prism\Tool;
 
@@ -38,7 +37,7 @@ it('sets the cache typeif cacheType providerMeta is set on tool', function (mixe
         ->for('Searching the web')
         ->withStringParameter('query', 'the detailed search query')
         ->using(fn (): string => '[Search results]')
-        ->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]);
+        ->withProviderOptions(['cacheType' => $cacheType]);
 
     expect(ToolMap::map([$tool]))->toBe([[
         'name' => 'search',

--- a/tests/Schemas/Converse/ConverseStructuredHandlerTest.php
+++ b/tests/Schemas/Converse/ConverseStructuredHandlerTest.php
@@ -28,7 +28,7 @@ it('returns structured output', function (): void {
     $response = Prism::structured()
         ->withSchema($schema)
         ->using('bedrock', 'anthropic.claude-3-5-haiku-20241022-v1:0')
-        ->withProviderMeta('bedrock', ['apiSchema' => BedrockSchema::Converse])
+        ->withProviderOptions(['apiSchema' => BedrockSchema::Converse])
         ->withSystemPrompt('The tigers game is at 3pm and the temperature will be 70º')
         ->withPrompt('What time is the tigers game today and should I wear a coat?')
         ->asStructured();

--- a/tests/Schemas/Converse/ConverseTextHandlerTest.php
+++ b/tests/Schemas/Converse/ConverseTextHandlerTest.php
@@ -96,7 +96,7 @@ it('can send images from file', function (): void {
 
     $response = Prism::text()
         ->using('bedrock', 'anthropic.claude-3-5-sonnet-20241022-v2:0')
-        ->withProviderMeta('bedrock', ['apiSchema' => BedrockSchema::Converse])
+        ->withProviderOptions(['apiSchema' => BedrockSchema::Converse])
         ->withMessages([
             new UserMessage(
                 'What is this image',
@@ -239,7 +239,7 @@ it('enables prompt caching if the enableCaching provider meta is set on the requ
 
     Prism::text()
         ->using('bedrock', 'amazon.nova-micro-v1:0')
-        ->withProviderMeta('bedrock', ['enableCaching' => true])
+        ->withProviderOptions(['enableCaching' => true])
         ->withPrompt('Who are you?')
         ->asText();
 

--- a/tests/Schemas/Converse/Maps/MessageMapTest.php
+++ b/tests/Schemas/Converse/Maps/MessageMapTest.php
@@ -157,7 +157,7 @@ it('maps tool result messages', function (): void {
 
 it('maps user messages with a cache breakpoint correctly', function (): void {
     expect(MessageMap::map([
-        (new UserMessage('Who are you?'))->withProviderMeta('bedrock', ['cacheType' => 'default']),
+        (new UserMessage('Who are you?'))->withProviderOptions(['cacheType' => 'default']),
     ]))->toBe([[
         'role' => 'user',
         'content' => [
@@ -173,7 +173,7 @@ it('maps user messages with a cache breakpoint correctly', function (): void {
 
 it('maps assistant messages with a cache breakpoint correctly', function (): void {
     expect(MessageMap::map([
-        (new AssistantMessage('I am Thanos'))->withProviderMeta('bedrock', ['cacheType' => 'default']),
+        (new AssistantMessage('I am Thanos'))->withProviderOptions(['cacheType' => 'default']),
     ]))->toBe([[
         'role' => 'assistant',
         'content' => [
@@ -189,7 +189,7 @@ it('maps assistant messages with a cache breakpoint correctly', function (): voi
 
 it('maps system messages with a cache breakpoint correctly', function (): void {
     expect(MessageMap::mapSystemMessages([
-        (new SystemMessage('The answer to life is 42.'))->withProviderMeta('bedrock', ['cacheType' => 'default']),
+        (new SystemMessage('The answer to life is 42.'))->withProviderOptions(['cacheType' => 'default']),
         (new SystemMessage('Convert any numbers in your answer to their word format.')),
     ]))->toBe([
         [


### PR DESCRIPTION
## Description
Updates to use `providerOptions` instead of `providerMeta` to support Prism >= 0.63

## Breaking Changes
- withProviderMeta has changed to withProviderOptions
- withProviderOptions no longer uses provider keys, they its now just an open bag of options for the currently configured provider
