### PR TITLE
feat: expose converse options via providerOptions

### DIFF
--- a/src/Schemas/Converse/ConverseStructuredHandler.php
+++ b/src/Schemas/Converse/ConverseStructuredHandler.php
@@ -70,12 +70,18 @@ class ConverseStructuredHandler extends BedrockStructuredHandler
     public static function buildPayload(Request $request): array
     {
         return array_filter([
+            'additionalModelRequestFields' => $request->providerOptions('additionalModelRequestFields'),
+            'additionalModelResponseFieldPaths' => $request->providerOptions('additionalModelResponseFieldPaths'),
+            'guardrailConfig' => $request->providerOptions('guardrailConfig'),
             'inferenceConfig' => array_filter([
                 'maxTokens' => $request->maxTokens(),
                 'temperature' => $request->temperature(),
                 'topP' => $request->topP(),
             ]),
             'messages' => MessageMap::map($request->messages()),
+            'performanceConfig' => $request->providerOptions('performanceConfig'),
+            'promptVariables' => $request->providerOptions('promptVariables'),
+            'requestMetadata' => $request->providerOptions('requestMetadata'),
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
         ]);
     }

--- a/src/Schemas/Converse/ConverseTextHandler.php
+++ b/src/Schemas/Converse/ConverseTextHandler.php
@@ -71,18 +71,12 @@ class ConverseTextHandler extends BedrockTextHandler
     public static function buildPayload(Request $request, int $stepCount = 0): array
     {
         return array_filter([
-            'additionalModelRequestFields' => $request->providerOptions('additionalModelRequestFields'),
-            'additionalModelResponseFieldPaths' => $request->providerOptions('additionalModelResponseFieldPaths'),
-            'guardrailConfig' => $request->providerOptions('guardrailConfig'),
             'inferenceConfig' => array_filter([
                 'maxTokens' => $request->maxTokens(),
                 'temperature' => $request->temperature(),
                 'topP' => $request->topP(),
             ]),
             'messages' => MessageMap::map($request->messages()),
-            'performanceConfig' => $request->providerOptions('performanceConfig'),
-            'promptVariables' => $request->providerOptions('promptVariables'),
-            'requestMetadata' => $request->providerOptions('requestMetadata'),
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
             'toolConfig' => $request->tools() === []
                 ? null
@@ -90,6 +84,12 @@ class ConverseTextHandler extends BedrockTextHandler
                     'tools' => ToolMap::map($request->tools()),
                     'toolChoice' => $stepCount === 0 ? ToolChoiceMap::map($request->toolChoice()) : null,
                 ]),
+            'additionalModelRequestFields' => $request->providerOptions('additionalModelRequestFields'),
+            'additionalModelResponseFieldPaths' => $request->providerOptions('additionalModelResponseFieldPaths'),
+            'guardrailConfig' => $request->providerOptions('guardrailConfig'),
+            'performanceConfig' => $request->providerOptions('performanceConfig'),
+            'promptVariables' => $request->providerOptions('promptVariables'),
+            'requestMetadata' => $request->providerOptions('requestMetadata'),
         ]);
     }
 

--- a/src/Schemas/Converse/ConverseTextHandler.php
+++ b/src/Schemas/Converse/ConverseTextHandler.php
@@ -71,12 +71,18 @@ class ConverseTextHandler extends BedrockTextHandler
     public static function buildPayload(Request $request, int $stepCount = 0): array
     {
         return array_filter([
+            'additionalModelRequestFields' => $request->providerOptions('additionalModelRequestFields'),
+            'additionalModelResponseFieldPaths' => $request->providerOptions('additionalModelResponseFieldPaths'),
+            'guardrailConfig' => $request->providerOptions('guardrailConfig'),
             'inferenceConfig' => array_filter([
                 'maxTokens' => $request->maxTokens(),
                 'temperature' => $request->temperature(),
                 'topP' => $request->topP(),
             ]),
             'messages' => MessageMap::map($request->messages()),
+            'performanceConfig' => $request->providerOptions('performanceConfig'),
+            'promptVariables' => $request->providerOptions('promptVariables'),
+            'requestMetadata' => $request->providerOptions('requestMetadata'),
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
             'toolConfig' => $request->tools() === []
                 ? null

--- a/tests/Fixtures/converse/with-converse-options-1.json
+++ b/tests/Fixtures/converse/with-converse-options-1.json
@@ -1,0 +1,1 @@
+{"Message":"Unexpected value type in payload"}

--- a/tests/Schemas/Converse/ConverseStructuredHandlerTest.php
+++ b/tests/Schemas/Converse/ConverseStructuredHandlerTest.php
@@ -9,6 +9,8 @@ use Prism\Prism\Prism;
 use Prism\Prism\Schema\BooleanSchema;
 use Prism\Prism\Schema\ObjectSchema;
 use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Structured\ResponseBuilder;
+use Prism\Prism\Testing\StructuredStepFake;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {
@@ -49,4 +51,46 @@ it('returns structured output', function (): void {
     expect($response->usage->cacheReadInputTokens)->toBeNull();
     expect($response->meta->id)->toBe('');
     expect($response->meta->model)->toBe('');
+});
+
+it('maps converse options when set with providerOptions', function (): void {
+    $fake = Prism::fake([
+        (new ResponseBuilder)->addStep(
+            StructuredStepFake::make()->withText(json_encode(['foo' => 'bar']))
+        )->toResponse(),
+    ]);
+
+    $providerOptions = [
+        'apiSchema' => BedrockSchema::Converse,
+        'additionalModelRequestFields' => [
+            'anthropic_beta' => ['output-128k-2025-02-19'],
+            'thinking' => ['type' => 'enabled', 'budget_tokens' => 16000],
+        ],
+        'additionalModelResponseFieldPaths' => ['foo.bar', 'baz.qux'],
+        'guardrailConfig' => ['rules' => ['no-violence']],
+        'performanceConfig' => ['timeoutMs' => 2000],
+        'promptVariables' => ['userName' => 'Alice'],
+        'requestMetadata' => ['requestId' => 'abc-123'],
+    ];
+
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('weather', 'The weather forecast'),
+            new StringSchema('game_time', 'The tigers game time'),
+            new BooleanSchema('coat_required', 'whether a coat is required'),
+        ],
+        ['weather', 'game_time', 'coat_required']
+    );
+
+    $response = Prism::structured()
+        ->withSchema($schema)
+        ->using('bedrock', 'anthropic.claude-3-5-haiku-20241022-v1:0')
+        ->withProviderOptions($providerOptions)
+        ->withSystemPrompt('The tigers game is at 3pm and the temperature will be 70º')
+        ->withPrompt('What time is the tigers game today and should I wear a coat?')
+        ->asStructured();
+
+    $fake->assertRequest(fn (array $requests): mixed => expect($requests[0]->providerOptions())->toBe($providerOptions));
 });

--- a/tests/Schemas/Converse/ConverseTextHandlerTest.php
+++ b/tests/Schemas/Converse/ConverseTextHandlerTest.php
@@ -6,11 +6,16 @@ namespace Tests\Schemas\Converse;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Mockery;
 use Prism\Bedrock\Enums\BedrockSchema;
+use Prism\Bedrock\Schemas\Converse\ConverseTextHandler;
+use Prism\Bedrock\Schemas\Converse\Maps\MessageMap;
 use Prism\Prism\Facades\Tool;
 use Prism\Prism\Prism;
+use Prism\Prism\Text\Request as PrismRequest;
 use Prism\Prism\ValueObjects\Messages\Support\Document;
 use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Tests\Fixtures\FixtureResponse;
 
@@ -244,4 +249,91 @@ it('enables prompt caching if the enableCaching provider meta is set on the requ
         ->asText();
 
     Http::assertSent(fn (Request $request): bool => $request->header('explicitPromptCaching')[0] === 'enabled');
+});
+
+it('builds payload with all new providerOptions fields', function (): void {
+    // 1) Mock the incoming Request
+    $request = Mockery::mock(PrismRequest::class);
+
+    // providerOptions fields you’ve just added
+    $request->shouldReceive('providerOptions')
+        ->with('additionalModelRequestFields')
+        ->andReturn([
+            'anthropic_beta' => ['output-128k-2025-02-19'],
+            'thinking' => ['type' => 'enabled', 'budget_tokens' => 16000],
+        ]);
+    $request->shouldReceive('providerOptions')
+        ->with('additionalModelResponseFieldPaths')
+        ->andReturn(['foo.bar', 'baz.qux']);
+    $request->shouldReceive('providerOptions')
+        ->with('guardrailConfig')
+        ->andReturn(['rules' => ['no-violence']]);
+    $request->shouldReceive('providerOptions')
+        ->with('performanceConfig')
+        ->andReturn(['timeoutMs' => 2000]);
+    $request->shouldReceive('providerOptions')
+        ->with('promptVariables')
+        ->andReturn(['userName' => 'Alice']);
+    $request->shouldReceive('providerOptions')
+        ->with('requestMetadata')
+        ->andReturn(['requestId' => 'abc-123']);
+
+    // the existing inferenceConfig bits
+    $request->shouldReceive('maxTokens')->andReturn(1234);
+    $request->shouldReceive('temperature')->andReturn(0.42);
+    $request->shouldReceive('topP')->andReturn(0.99);
+
+    // messages & systemPrompts
+    $rawMessages = [new UserMessage(
+        'foo-message',
+    )];
+    $mappedMessages = [
+        [
+            'role' => 'user',
+            'content' => [
+                [
+                    'text' => 'foo-message',
+                ],
+            ],
+        ],
+    ];
+    $rawSystem = [new SystemMessage(
+        'system-prompt',
+    )];
+    $mappedSystem = [
+        [
+            'text' => 'system-prompt',
+        ],
+    ];
+
+    $request->shouldReceive('messages')->andReturn($rawMessages);
+    $request->shouldReceive('systemPrompts')->andReturn($rawSystem);
+
+    $request->shouldReceive('tools')->andReturn([]);
+
+    // 3) Alias‐mock the MessageMap class so its statics can be stubbed
+    $mapper = Mockery::mock(MessageMap::class);
+
+    // 3) Call your new payload builder
+    $payload = ConverseTextHandler::buildPayload($request);
+
+    // 4) Assert exactly what you expect
+    expect($payload)->toBe([
+        'additionalModelRequestFields' => [
+            'anthropic_beta' => ['output-128k-2025-02-19'],
+            'thinking' => ['type' => 'enabled', 'budget_tokens' => 16000],
+        ],
+        'additionalModelResponseFieldPaths' => ['foo.bar', 'baz.qux'],
+        'guardrailConfig' => ['rules' => ['no-violence']],
+        'inferenceConfig' => [
+            'maxTokens' => 1234,
+            'temperature' => 0.42,
+            'topP' => 0.99,
+        ],
+        'messages' => $mappedMessages,
+        'performanceConfig' => ['timeoutMs' => 2000],
+        'promptVariables' => ['userName' => 'Alice'],
+        'requestMetadata' => ['requestId' => 'abc-123'],
+        'system' => $mappedSystem,
+    ]);
 });


### PR DESCRIPTION
## Description
Mirrors options for the converse API.
As there doesn't seem to be any matching functions exported from the core Prism interface it feels viable to have them as provider specific options.
Completely understandable if there's a reason you excluded it in the first place.
I'm mainly interested in 'additionalModelRequestFields', since that enables control of the thinking block for claude 3.7.

