### PR TITLE
fix: Allow 0 as a value for temperature, topP, etc.

### DIFF
--- a/src/Schemas/Anthropic/AnthropicStructuredHandler.php
+++ b/src/Schemas/Anthropic/AnthropicStructuredHandler.php
@@ -79,7 +79,7 @@ class AnthropicStructuredHandler extends BedrockStructuredHandler
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
-        ]);
+        ], fn ($value): bool => $value !== null);
     }
 
     protected function sendRequest(Request $request): void

--- a/src/Schemas/Anthropic/AnthropicTextHandler.php
+++ b/src/Schemas/Anthropic/AnthropicTextHandler.php
@@ -80,7 +80,7 @@ class AnthropicTextHandler extends BedrockTextHandler
             'top_p' => $request->topP(),
             'tools' => ToolMap::map($request->tools()),
             'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
-        ]);
+        ], fn ($value): bool => $value !== null);
     }
 
     protected function sendRequest(Request $request): void

--- a/src/Schemas/Converse/ConverseStructuredHandler.php
+++ b/src/Schemas/Converse/ConverseStructuredHandler.php
@@ -77,7 +77,7 @@ class ConverseStructuredHandler extends BedrockStructuredHandler
                 'maxTokens' => $request->maxTokens(),
                 'temperature' => $request->temperature(),
                 'topP' => $request->topP(),
-            ]),
+            ], fn ($value): bool => $value !== null),
             'messages' => MessageMap::map($request->messages()),
             'performanceConfig' => $request->providerOptions('performanceConfig'),
             'promptVariables' => $request->providerOptions('promptVariables'),

--- a/src/Schemas/Converse/ConverseTextHandler.php
+++ b/src/Schemas/Converse/ConverseTextHandler.php
@@ -75,7 +75,7 @@ class ConverseTextHandler extends BedrockTextHandler
                 'maxTokens' => $request->maxTokens(),
                 'temperature' => $request->temperature(),
                 'topP' => $request->topP(),
-            ]),
+            ], fn ($value): bool => $value !== null),
             'messages' => MessageMap::map($request->messages()),
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
             'toolConfig' => $request->tools() === []

--- a/tests/Schemas/Anthropic/AnthropicTextHandlerTest.php
+++ b/tests/Schemas/Anthropic/AnthropicTextHandlerTest.php
@@ -193,3 +193,17 @@ it('enables prompt caching if the enableCaching provider meta is set on the requ
 
     Http::assertSent(fn (Request $request): bool => $request->header('explicitPromptCaching')[0] === 'enabled');
 });
+
+it('does not remove 0 values from payloads', function (): void {
+    FixtureResponse::fakeResponseSequence('invoke', 'anthropic/generate-text-with-a-prompt');
+
+    Prism::text()
+        ->using('bedrock', 'anthropic.claude-3-5-haiku-20241022-v1:0')
+        ->withPrompt('Who are you?')
+        ->usingTemperature(0)
+        ->asText();
+
+    Http::assertSent(fn (Request $request): \Pest\Mixins\Expectation|\Pest\Expectation => expect($request->data())->toMatchArray([
+        'temperature' => 0,
+    ]));
+});

--- a/tests/Schemas/Converse/ConverseTextHandlerTest.php
+++ b/tests/Schemas/Converse/ConverseTextHandlerTest.php
@@ -273,3 +273,20 @@ it('maps converse options when set with providerOptions', function (): void {
 
     $fake->assertRequest(fn (array $requests): mixed => expect($requests[0]->providerOptions())->toBe($providerOptions));
 });
+
+it('does not remove zero values from payload', function (): void {
+    FixtureResponse::fakeResponseSequence('converse', 'converse/generate-text-with-a-prompt');
+
+    Prism::text()
+        ->using('bedrock', 'amazon.nova-micro-v1:0')
+        ->withPrompt('Who are you?')
+        ->usingTemperature(0)
+        ->asText();
+
+    Http::assertSent(fn (Request $request): \Pest\Mixins\Expectation|\Pest\Expectation => expect($request->data())->toMatchArray([
+        'inferenceConfig' => [
+            'temperature' => 0,
+            'maxTokens' => 2048,
+        ],
+    ]));
+});


### PR DESCRIPTION
## Description

The `buildPayload()` methods are using `array_filter()` without a callback which will remove any falsey values such as the literal 0 value. This is a problem if you want to set your `temperature` to 0 or your `topP` to 0 because those values will be filtered out. The code was updated to provide a callback that checks for `null` values explicitly. 
