### PR TITLE
Lazily extend PrismManager

### DIFF
--- a/src/BedrockServiceProvider.php
+++ b/src/BedrockServiceProvider.php
@@ -5,6 +5,7 @@ namespace Prism\Bedrock;
 use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Illuminate\Support\ServiceProvider;
+use Prism\Prism\PrismManager;
 
 class BedrockServiceProvider extends ServiceProvider
 {
@@ -33,9 +34,13 @@ class BedrockServiceProvider extends ServiceProvider
 
     protected function registerWithPrism(): void
     {
-        $this->app->get('prism-manager')->extend(Bedrock::KEY, fn ($app, $config): \Prism\Bedrock\Bedrock => new Bedrock(
-            credentials: BedrockServiceProvider::getCredentials($config),
-            region: $config['region']
-        ));
+        $this->app->extend(PrismManager::class, function (PrismManager $prismManager): \Prism\Prism\PrismManager {
+            $prismManager->extend(Bedrock::KEY, fn ($app, $config): Bedrock => new Bedrock(
+                credentials: BedrockServiceProvider::getCredentials($config),
+                region: $config['region']
+            ));
+
+            return $prismManager;
+        });
     }
 }


### PR DESCRIPTION
In the old `BedrockServiceProvider.php` it was calling `$this->app->get('prism-manager')` which would resolve `PrismManager` from the container on every Laravel application boot. It would resolve and extend `PrismManager` even if the request being served did not need `PrismManager`. By updating it to use `app->extend()` it will only run that code if PrismManager is resolved from the container which is more efficient.