### PR TITLE
fix: schema detection with cross region inference

### DIFF
--- a/src/Enums/BedrockSchema.php
+++ b/src/Enums/BedrockSchema.php
@@ -63,6 +63,14 @@ enum BedrockSchema: string
 
     public static function fromModelString(string $string): self
     {
-        return self::tryFrom(Str::before($string, '.')) ?? self::Converse;
+        if (Str::contains($string, 'anthropic.')) {
+            return self::Anthropic;
+        }
+
+        if (Str::contains($string, 'cohere.')) {
+            return self::Cohere;
+        }
+
+        return self::Converse;
     }
 }


### PR DESCRIPTION
## Description

Switches schema detection to use "contains" instead of "before". Without, the package will default to Converse when using country codes in the model name for cross region inference (e.g. us.anthropic.claude-opus-4-20250514-v1:0).
