### PR TITLE
DRAFT: Streaming support

### DIFF
--- a/src/Bedrock.php
+++ b/src/Bedrock.php
@@ -2,6 +2,7 @@
 
 namespace Prism\Bedrock;
 
+use Aws\BedrockRuntime\BedrockRuntimeClient;
 use Aws\Credentials\Credentials;
 use Aws\Signature\SignatureV4;
 use Generator;
@@ -16,6 +17,7 @@ use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Structured\Request as StructuredRequest;
 use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Chunk;
 use Prism\Prism\Text\Request as TextRequest;
 use Prism\Prism\Text\Response as TextResponse;
 
@@ -100,7 +102,15 @@ class Bedrock implements Provider
      */
     public function stream(TextRequest $request): Generator
     {
-        throw new PrismException('Prism Bedrock does not support streaming yet.');
+        $schema = BedrockSchema::Converse;
+
+        $handler = $schema->streamHandler();
+
+        $client = $this->bedrockClient();
+
+        $handler = new $handler($this, $client);
+
+        return $handler->handle($request);
     }
 
     public function schema(PrismRequest $request): BedrockSchema
@@ -115,6 +125,11 @@ class Bedrock implements Provider
     public function apiVersion(PrismRequest $request): ?string
     {
         return $this->schema($request)->defaultApiVersion();
+    }
+
+    protected function bedrockClient(): BedrockRuntimeClient
+    {
+        return app(BedrockClientFactory::class)->make();
     }
 
     /**

--- a/src/BedrockClientFactory.php
+++ b/src/BedrockClientFactory.php
@@ -10,11 +10,11 @@ class BedrockClientFactory
     public function make(?HandlerStack $handler = null): BedrockRuntimeClient
     {
         $config = [
-            'region' => config('services.bedrock.region', 'eu-central-1'),
-            'version' => config('services.bedrock.version', 'latest'),
+            'region' => config('prism.providers.bedrock.region', 'eu-central-1'),
+            'version' => config('prism.providers.bedrock.version', 'latest'),
             'credentials' => [
-                'key' => config('services.bedrock.api_key', ''),
-                'secret' => config('services.bedrock.api_secret', ''),
+                'key' => config('prism.providers.bedrock.api_key', ''),
+                'secret' => config('prism.providers.bedrock.api_secret', ''),
             ],
         ];
 

--- a/src/BedrockClientFactory.php
+++ b/src/BedrockClientFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Prism\Bedrock;
+
+use Aws\BedrockRuntime\BedrockRuntimeClient;
+use GuzzleHttp\HandlerStack;
+
+class BedrockClientFactory
+{
+    public function make(?HandlerStack $handler = null): BedrockRuntimeClient
+    {
+        $config = [
+            'region' => config('services.bedrock.region', 'eu-central-1'),
+            'version' => config('services.bedrock.version', 'latest'),
+            'credentials' => [
+                'key' => config('services.bedrock.api_key', ''),
+                'secret' => config('services.bedrock.api_secret', ''),
+            ],
+        ];
+
+        if ($handler instanceof \GuzzleHttp\HandlerStack) {
+            $config['http'] = ['handler' => $handler];
+        }
+
+        return new BedrockRuntimeClient($config);
+    }
+}

--- a/src/BedrockServiceProvider.php
+++ b/src/BedrockServiceProvider.php
@@ -43,4 +43,9 @@ class BedrockServiceProvider extends ServiceProvider
             return $prismManager;
         });
     }
+
+    protected function registerBedrockClient(): void
+    {
+        $this->app->singleton(BedrockClientFactory::class, fn (): \Prism\Bedrock\BedrockClientFactory => new BedrockClientFactory);
+    }
 }

--- a/src/Contracts/BedrockStreamHandler.php
+++ b/src/Contracts/BedrockStreamHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Prism\Bedrock\Contracts;
+
+use Aws\BedrockRuntime\BedrockRuntimeClient;
+use Generator;
+use Prism\Bedrock\Bedrock;
+use Prism\Prism\Text\Request;
+
+abstract class BedrockStreamHandler
+{
+    public function __construct(
+        protected Bedrock $provider,
+        protected BedrockRuntimeClient $client
+    ) {}
+
+    abstract public function handle(Request $request): Generator;
+}

--- a/src/Enums/BedrockSchema.php
+++ b/src/Enums/BedrockSchema.php
@@ -9,8 +9,10 @@ use Prism\Bedrock\Contracts\BedrockTextHandler;
 use Prism\Bedrock\Schemas\Anthropic\AnthropicStructuredHandler;
 use Prism\Bedrock\Schemas\Anthropic\AnthropicTextHandler;
 use Prism\Bedrock\Schemas\Cohere\CohereEmbeddingsHandler;
+use Prism\Bedrock\Schemas\Converse\ConverseStreamHandler;
 use Prism\Bedrock\Schemas\Converse\ConverseStructuredHandler;
 use Prism\Bedrock\Schemas\Converse\ConverseTextHandler;
+use Prism\Prism\Exceptions\PrismException;
 
 enum BedrockSchema: string
 {
@@ -27,6 +29,17 @@ enum BedrockSchema: string
             self::Anthropic => AnthropicTextHandler::class,
             self::Converse => ConverseTextHandler::class,
             default => null
+        };
+    }
+
+    /**
+     * @return null|class-string<ConverseStreamHandler>
+     */
+    public function streamHandler(): ?string
+    {
+        return match ($this) {
+            self::Converse => ConverseStreamHandler::class,
+            default => throw new PrismException('Prism Bedrock only supports streaming for Converse.'),
         };
     }
 

--- a/src/Exceptions/BedrockException.php
+++ b/src/Exceptions/BedrockException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Prism\Bedrock\Exceptions;
+
+class BedrockException extends \Exception {}

--- a/src/HandlesStream.php
+++ b/src/HandlesStream.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Prism\Bedrock;
+
+use Aws\Result;
+use Generator;
+use Prism\Bedrock\Exceptions\BedrockException;
+use Prism\Prism\Enums\ChunkType;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Anthropic\Maps\FinishReasonMap;
+use Prism\Prism\Text\Chunk;
+use Prism\Prism\Text\Request;
+
+trait HandlesStream
+{
+    public function processStream(Result $result, Request $request, int $depth = 0): Generator
+    {
+        $this->state->reset();
+
+        $this->validateToolCallDepth($request, $depth);
+
+        yield from $this->processStreamChunks($result, $request, $depth);
+
+        if ($this->state->hasToolCalls()) {
+            yield from $this->handleToolUseFinish($request, $depth);
+        }
+    }
+
+    protected function validateToolCallDepth(Request $request, int $depth): void
+    {
+        if ($depth >= $request->maxSteps()) {
+            throw new PrismException('Maximum tool call chain depth exceeded');
+        }
+    }
+
+    protected function processStreamChunks(Result $result, Request $request, int $depth): Generator
+    {
+
+        foreach ($result->get('stream') as $event) {
+
+            $outcome = $this->processChunk($event, $request, $depth);
+
+            if ($outcome instanceof Generator) {
+                yield from $outcome;
+            }
+
+            if ($outcome instanceof Chunk) {
+                yield $outcome;
+            }
+        }
+    }
+
+    protected function processChunk(array $chunk, Request $request, int $depth): Generator|Chunk|null
+    {
+        return match (array_key_first($chunk) ?? null) {
+            'messageStart' => $this->handleMessageStart(data_get($chunk, 'messageStart')),
+            'contentBlockDelta' => $this->handleContentBlockDelta(data_get($chunk, 'contentBlockDelta')),
+            'contentBlockStop' => $this->handleContentBlockStop(),
+            'messageStop' => $this->handleMessageStop(data_get($chunk, 'messageStop'), $depth),
+            'metadata' => $this->handleMetadata(data_get($chunk, 'metadata')),
+            'modelStreamErrorException' => $this->handleException(data_get($chunk, 'modelStreamErrorException')),
+            'serviceUnavailableException' => $this->handleException(data_get($chunk, 'serviceUnavailableException')),
+            'throttlingException' => $this->handleException(data_get($chunk, 'throttlingException')),
+            'validationException' => $this->handleException(data_get($chunk, 'validationException')),
+            default => null,
+        };
+    }
+
+    protected function handleMessageStart(array $chunk): null
+    {
+        // {
+        // messageStart: {
+        //      role: assistant
+        // }
+
+        return null;
+    }
+
+    protected function handleContentBlockDelta(array $chunk): ?Chunk
+    {
+        if ($text = data_get($chunk, 'delta.text')) {
+            return $this->handleTextBlockDelta($text, (int) data_get($chunk, 'contentBlockIndex'));
+        }
+
+        if ($reasoningContent = data_get($chunk, 'delta.reasoningContent')) {
+            return $this->handleReasoningContentBlockDelta($reasoningContent);
+        }
+
+        if ($toolUse = data_get($chunk, 'delta.toolUse')) {
+            return $this->handleToolUseBlockDelta($toolUse);
+        }
+
+        return null;
+    }
+
+    protected function handleTextBlockDelta(string $text, int $contentBlockIndex): Chunk
+    {
+        $this->state->appendText($text);
+
+        return new Chunk(
+            text: $text,
+            additionalContent: [
+                'contentBlockIndex' => $contentBlockIndex,
+            ],
+            chunkType: ChunkType::Text
+        );
+    }
+
+    protected function handleReasoningContentBlockDelta(array $reasoningContent): Chunk
+    {
+        $text = data_get($reasoningContent, 'reasoningText.text', '');
+        $signature = data_get($reasoningContent, 'reasoningText.signature', '');
+
+        $this->state->appendThinking($text);
+        $this->state->appendThinkingSignature($signature);
+
+        return new Chunk(
+            text: $text,
+            chunkType: ChunkType::Thinking
+        );
+    }
+
+    protected function handleContentBlockStop(): void
+    {
+        $this->state->resetContentBlock();
+    }
+
+    protected function handleMessageStop(array $chunk, int $depth): Generator|Chunk
+    {
+        $this->state->setStopReason(data_get($chunk, 'stopReason'));
+
+        if ($this->state->isToolUseFinish()) {
+            return $this->handleToolUseFinish($chunk, $depth);
+        }
+
+        return new Chunk(
+            text: $this->state->text(),
+            finishReason: FinishReasonMap::map($this->state->stopReason()),
+            additionalContent: $this->state->buildAdditionalContent(),
+            chunkType: ChunkType::Meta
+        );
+    }
+
+    protected function handleMetadata(array $chunk): void
+    {
+        // {"metadata":{"usage":{"inputTokens":11,"outputTokens":48,"totalTokens":59},"metrics":{"latencyMs":1269}}}
+        // not sure yet where to store this information.
+    }
+
+    protected function handleException(array $chunk): void
+    {
+        throw new BedrockException(data_get($chunk, 'message'));
+    }
+
+    protected function handleToolUseBlockDelta(array $toolUse): void
+    {
+        throw new \Exception('Tool use not yet supported');
+    }
+
+    public function handleToolUseFinish(Request $request, int $depth): void
+    {
+        throw new \Exception('Tool use not yet supported');
+    }
+}

--- a/src/Schemas/Converse/ConverseStreamHandler.php
+++ b/src/Schemas/Converse/ConverseStreamHandler.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Prism\Bedrock\Schemas\Converse;
+
+use Aws\Result;
+use Generator;
+use Prism\Bedrock\Contracts\BedrockStreamHandler;
+use Prism\Bedrock\HandlesStream;
+use Prism\Bedrock\Schemas\Converse\Maps\MessageMap;
+use Prism\Bedrock\Schemas\Converse\Maps\ToolChoiceMap;
+use Prism\Bedrock\Schemas\Converse\Maps\ToolMap;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Exceptions\PrismChunkDecodeException;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Providers\Anthropic\Concerns\HandlesResponse;
+use Prism\Prism\Providers\Anthropic\ValueObjects\StreamState;
+use Prism\Prism\Text\Chunk;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\ResponseBuilder;
+use Throwable;
+
+class ConverseStreamHandler extends BedrockStreamHandler
+{
+    use CallsTools, HandlesResponse, HandlesStream;
+
+    protected StreamState $state;
+
+    protected ResponseBuilder $responseBuilder;
+
+    public function __construct(mixed ...$args)
+    {
+        parent::__construct(...$args);
+
+        $this->state = new StreamState;
+
+        $this->responseBuilder = new ResponseBuilder;
+    }
+
+    /**
+     * @return Generator<Chunk>
+     *
+     * @throws PrismChunkDecodeException
+     * @throws PrismException
+     * @throws PrismRateLimitedException
+     */
+    public function handle(Request $request): Generator
+    {
+        $result = $this->sendRequest($request);
+
+        return $this->processStream($result, $request);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public static function buildPayload(Request $request, int $stepCount = 0): array
+    {
+        return array_filter([
+            'anthropic_version' => 'bedrock-2023-05-31',
+            '@http' => [
+                'stream' => true,
+            ],
+            'modelId' => $request->model(),
+            'max_tokens' => $request->maxTokens(),
+            'temperature' => $request->temperature(),
+            'top_p' => $request->topP(),
+            'messages' => MessageMap::map($request->messages()),
+            'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
+            'toolConfig' => $request->tools() === []
+                ? null
+                : array_filter([
+                    'tools' => ToolMap::map($request->tools()),
+                    'toolChoice' => $stepCount === 0 ? ToolChoiceMap::map($request->toolChoice()) : null,
+                ]),
+        ]);
+    }
+    protected function sendRequest(Request $request): Result
+    {
+        try {
+            $payload = static::buildPayload($request, $this->responseBuilder->steps->count());
+
+            return $this->client->converseStream($payload);
+        } catch (Throwable $e) {
+            throw PrismException::providerRequestError($request->model(), $e);
+        }
+    }
+}

--- a/tests/Fixtures/BedrockRuntimeClientMockResponse.php
+++ b/tests/Fixtures/BedrockRuntimeClientMockResponse.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Aws\BedrockRuntime\BedrockRuntimeClient;
+use Aws\Result;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Psr7\Response;
+use Prism\Bedrock\BedrockClientFactory;
+use Psr\Http\Message\RequestInterface;
+
+class BedrockRuntimeClientMockResponse
+{
+    public static function mock(Result $fakeResult): void
+    {
+        $mockHandler = new MockHandler([
+            fn (RequestInterface $request, array $options): \GuzzleHttp\Psr7\Response => new Response(200, [
+                'Content-Type' => 'application/vnd.amazon.eventstream',
+            ], ''),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+
+        app()->singleton(BedrockClientFactory::class, fn(): \Prism\Bedrock\BedrockClientFactory => new class($handlerStack, $fakeResult) extends BedrockClientFactory
+        {
+            public function __construct(
+                private readonly HandlerStack $handler,
+                private readonly Result $fakeResult
+            ) {}
+
+            public function make(?HandlerStack $handler = null): BedrockRuntimeClient
+            {
+                $client = parent::make($this->handler);
+
+                $client->getHandlerList()->setHandler(
+                    fn($command, $request): \GuzzleHttp\Promise\PromiseInterface => $command->getName() === 'ConverseStream'
+                        ? Create::promiseFor($this->fakeResult)
+                        : Create::promiseFor([])
+                );
+
+                return $client;
+            }
+        });
+
+    }
+}

--- a/tests/Fixtures/FixtureResponse.php
+++ b/tests/Fixtures/FixtureResponse.php
@@ -80,7 +80,7 @@ class FixtureResponse
         }
 
         $lines = file($filePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        $events = array_map(fn ($line): mixed => json_decode((string) $line, true), $lines);
+        $events = array_map(fn ($line): mixed => json_decode($line, true), $lines);
 
         return new Result([
             'stream' => new ArrayIterator($events),

--- a/tests/Fixtures/FixtureResponse.php
+++ b/tests/Fixtures/FixtureResponse.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use ArrayIterator;
+use Aws\Result;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Support\Facades\Http;
 
@@ -67,5 +69,26 @@ class FixtureResponse
         Http::fake([
             $requestPath => Http::sequence($responses->toArray()),
         ])->preventStrayRequests();
+    }
+
+    public static function fakeConverseStream(string $name): Result
+    {
+        $filePath = static::filePath("{$name}-1.jsonl");
+
+        if (! file_exists($filePath)) {
+            throw new \RuntimeException("Fixture file not found: {$filePath}");
+        }
+
+        $lines = file($filePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $events = array_map(fn ($line): mixed => json_decode((string) $line, true), $lines);
+
+        return new Result([
+            'stream' => new ArrayIterator($events),
+            '@metadata' => [
+                'statusCode' => 200,
+                'headers' => [],
+                'effectiveUri' => 'https://bedrock-runtime...',
+            ],
+        ]);
     }
 }

--- a/tests/Fixtures/converse/stream-basic-text-1.jsonl
+++ b/tests/Fixtures/converse/stream-basic-text-1.jsonl
@@ -1,0 +1,14 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"delta":{"text":"I'm"},"contentBlockIndex":0}}
+{"contentBlockDelta":{"delta":{"text":" an AI"},"contentBlockIndex":0}}
+{"contentBlockDelta":{"delta":{"text":" assistant created by"},"contentBlockIndex":0}}
+{"contentBlockDelta":{"delta":{"text":" Anthropic to"},"contentBlockIndex":0}}
+{"contentBlockDelta":{"delta":{"text":" be helpful, harm"},"contentBlockIndex":0}}
+{"contentBlockDelta":{"delta":{"text":"less, and honest"},"contentBlockIndex":0}}
+{"contentBlockDelta":{"delta":{"text":". I"},"contentBlockIndex":0}}
+{"contentBlockDelta":{"delta":{"text":" don't have a"},"contentBlockIndex":0}}
+{"contentBlockDelta":{"delta":{"text":" physical body or"},"contentBlockIndex":0}}
+{"contentBlockDelta":{"delta":{"text":" avatar"},"contentBlockIndex":0}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"messageStop":{"stopReason":"end_turn"}}
+{"metadata":{"usage":{"inputTokens":11,"outputTokens":48,"totalTokens":59},"metrics":{"latencyMs":1269}}}

--- a/tests/Schemas/Converse/ConverseStreamHandlerTest.php
+++ b/tests/Schemas/Converse/ConverseStreamHandlerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Schemas\Converse;
+
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Tests\Fixtures\BedrockRuntimeClientMockResponse;
+use Tests\Fixtures\FixtureResponse;
+
+it('can generate text with a basic stream', function (): void {
+
+    $fakeResult = FixtureResponse::fakeConverseStream('converse/stream-basic-text');
+
+    BedrockRuntimeClientMockResponse::mock($fakeResult);
+
+    $response = Prism::text()
+        ->using('bedrock', 'anthropic.claude-3-5-sonnet-20240620-v1:0')
+        ->withMessages([new UserMessage('Who are you?')])
+        ->asStream();
+
+    $text = '';
+    $chunks = [];
+
+    foreach ($response as $chunk) {
+        $chunks[] = $chunk;
+        $text .= $chunk->text;
+    }
+
+    expect($chunks)->not->toBeEmpty();
+    expect($text)->not->toBeEmpty();
+    expect(end($chunks)->finishReason)->toBe(FinishReason::Stop);
+});


### PR DESCRIPTION
I have minimal viable stream working, but only tested with `anthropic.claude-3-5-sonnet-20240620-v1:0`.

It is far from complete, and it was a bit harder than I expected...

I'm still finding my way around the different schema's and message formats.

I tried to keep things as 'Prism' as possible, but to get the stream even decoding working I had to use the aws sdk client in order to retrieve readable events from `converseStream`.

Added this WIP PR for first feedback and to 'publish' the work to prevent doing double work if others are also working on this.

```php
        $stream = Prism::text()
            ->using(Bedrock::KEY, env('ANTHROPIC_MODEL'))
            ->withPrompt('Hi, how are you?')
            ->asStream();

        foreach ($stream as $chunk) {
            $this->line($chunk->text);
        }
```
<img width="989" alt="image" src="https://github.com/user-attachments/assets/83a5bb7a-6d4a-45db-b067-2497df1ef8ae" />
