### PR TITLE
refactoring map documents to work with latest prism release

### DIFF
--- a/src/Schemas/Converse/Maps/MessageMap.php
+++ b/src/Schemas/Converse/Maps/MessageMap.php
@@ -163,8 +163,8 @@ class MessageMap
 
             return [
                 'image' => [
-                    'format' => Mimes::tryFrom($image->mimeType)?->toExtension(), // @phpstan-ignore argument.type
-                    'source' => ['bytes' => $image->image],
+                    'format' => Mimes::tryFrom($image->mimeType())?->toExtension(), // @phpstan-ignore argument.type
+                    'source' => ['bytes' => $image->base64()],
                 ],
             ];
         }, $parts);
@@ -177,15 +177,11 @@ class MessageMap
     protected static function mapDocumentParts(array $parts): array
     {
         return array_map(function (Document $document): array {
-            if ($document->dataFormat === 'content') {
-                throw new Exception('Content data format is not supported');
-            }
-
             return [
                 'document' => [
-                    'format' => Mimes::tryFrom($document->mimeType)?->toExtension(), // @phpstan-ignore argument.type
-                    'name' => $document->documentTitle,
-                    'source' => ['bytes' => $document->dataFormat === 'base64' ? $document->document : base64_encode($document->document)], // @phpstan-ignore argument.type
+                    'format' => Mimes::tryFrom($document->mimeType())?->toExtension(),
+                    'name' => $document->documentTitle(),
+                    'source' => ['bytes' => $document->base64()],
                 ],
             ];
         }, $parts);


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

The latest prism release seems to have a breaking change for the Document and Media class definitions. This PR makes the document and image mapping for Converse use the new functions instead of trying to access the protected member variables.

