### PR TITLE
fix: URL encode model names to support inference profiles

### DIFF
--- a/src/Bedrock.php
+++ b/src/Bedrock.php
@@ -115,7 +115,7 @@ class Bedrock extends Provider
      */
     protected function client(TextRequest|StructuredRequest|EmbeddingRequest $request, array $options = [], array $retry = []): PendingRequest
     {
-        $model = $request->model();
+        $model = rawurlencode($request->model());
 
         $enableCaching = $request instanceof EmbeddingRequest
             ? false

--- a/tests/BedrockTest.php
+++ b/tests/BedrockTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Prism\Prism\Facades\Prism;
+use Tests\Fixtures\FixtureResponse;
+
+it('URL encodes model names with special characters like inference profiles', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'converse/generate-text-with-a-prompt');
+
+    // Test with an inference profile ARN that contains colons and slashes
+    $inferenceProfile = 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123def456';
+
+    Prism::text()
+        ->using('bedrock', $inferenceProfile)
+        ->withPrompt('Hello')
+        ->asText();
+
+    Http::assertSent(function (Request $request) use ($inferenceProfile): bool {
+        // The URL should contain encoded colons (%3A) and slashes (%2F)
+        return str_contains($request->url(), '%3A')
+            && str_contains($request->url(), '%2F')
+            && str_contains($request->url(), rawurlencode($inferenceProfile));
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `rawurlencode()` to model names before constructing the API endpoint URL
- Adds test coverage for URL encoding with inference profile ARNs

## Problem
AWS Bedrock inference profiles contain special characters (colons `:` and slashes `/`) in their ARNs that break the API endpoint path when not URL encoded.

Example inference profile:
```
arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123def456
```

## Solution
Apply `rawurlencode()` to the model name in the `Bedrock::client()` method before constructing the base URL. This ensures:
- Special characters are properly encoded (`%3A` for `:`, `%2F` for `/`)
- Inference profiles work correctly
- Standard model names continue to work as before

## Test Plan
- Added `tests/BedrockTest.php` with test verifying URL encoding
- Test confirms encoded characters appear in the request URL
- All existing tests continue to pass