### PR TITLE
Fix ToolChoiceMap producing invalid payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## v1.10.0 - 2026-03-19
+
+### Added
+
+- Laravel 13 support (`laravel/framework` ^13.0, `orchestra/testbench` ^11.0)

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "laravel/framework": "^11.0|^12.0",
+    "laravel/framework": "^11.0|^12.0|^13.0",
     "aws/aws-sdk-php": "^3.339",
     "prism-php/prism": ">=0.99.7"
   },
@@ -41,7 +41,7 @@
     "phpstan/phpstan-deprecation-rules": "^2.0",
     "rector/rector": "2.2.14",
     "projektgopher/whisky": "^0.7.0",
-    "orchestra/testbench": "^9.4",
+    "orchestra/testbench": "^9.4|^10.0|^11.0",
     "mockery/mockery": "^1.6",
     "symplify/rule-doc-generator-contracts": "^11.2",
     "phpstan/phpdoc-parser": "^2.0",

--- a/src/Schemas/Anthropic/Maps/ToolChoiceMap.php
+++ b/src/Schemas/Anthropic/Maps/ToolChoiceMap.php
@@ -10,9 +10,9 @@ use Prism\Prism\Enums\ToolChoice;
 class ToolChoiceMap
 {
     /**
-     * @return array<string, mixed>|string|null
+     * @return array<string, mixed>|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice): ?array
     {
         if (is_null($toolChoice)) {
             return null;
@@ -30,8 +30,8 @@ class ToolChoiceMap
         }
 
         return match ($toolChoice) {
-            ToolChoice::Auto => 'auto',
-            ToolChoice::Any => 'any',
+            ToolChoice::Auto => ['type' => 'auto'],
+            ToolChoice::Any => ['type' => 'any'],
         };
 
     }

--- a/src/Schemas/Converse/Maps/ToolChoiceMap.php
+++ b/src/Schemas/Converse/Maps/ToolChoiceMap.php
@@ -31,9 +31,7 @@ class ToolChoiceMap
         }
 
         return [
-            'tool' => [
-                ($toolChoice === ToolChoice::Auto ? 'auto' : 'any') => [],
-            ],
+            ($toolChoice === ToolChoice::Auto ? 'auto' : 'any') => new \stdClass,
         ];
     }
 }

--- a/tests/Schemas/Anthropic/Maps/ToolChoiceMapTest.php
+++ b/tests/Schemas/Anthropic/Maps/ToolChoiceMapTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Schemas\Anthropic\Maps;
+
+use InvalidArgumentException;
+use Prism\Bedrock\Schemas\Anthropic\Maps\ToolChoiceMap;
+use Prism\Prism\Enums\ToolChoice;
+
+it('returns null when tool choice is null', function (): void {
+    expect(ToolChoiceMap::map(null))->toBeNull();
+});
+
+it('maps a specific tool correctly', function (): void {
+    expect(ToolChoiceMap::map('search'))
+        ->toBe([
+            'type' => 'tool',
+            'name' => 'search',
+        ]);
+});
+
+it('maps auto tool correctly', function (): void {
+    expect(ToolChoiceMap::map(ToolChoice::Auto))
+        ->toBe(['type' => 'auto']);
+});
+
+it('maps any tool correctly', function (): void {
+    expect(ToolChoiceMap::map(ToolChoice::Any))
+        ->toBe(['type' => 'any']);
+});
+
+it('throws exception for invalid tool choice', function (): void {
+    ToolChoiceMap::map(ToolChoice::None);
+})->throws(InvalidArgumentException::class, 'Invalid tool choice');

--- a/tests/Schemas/Converse/Maps/ToolChoiceMapTest.php
+++ b/tests/Schemas/Converse/Maps/ToolChoiceMapTest.php
@@ -18,18 +18,14 @@ it('maps a specific tool correctly', function (): void {
 
 it('maps any tool correctly', function (): void {
     expect(ToolChoiceMap::map(ToolChoice::Any))
-        ->toBe([
-            'tool' => [
-                'any' => [],
-            ],
+        ->toEqual([
+            'any' => new \stdClass,
         ]);
 });
 
 it('maps auto tool correctly', function (): void {
     expect(ToolChoiceMap::map(ToolChoice::Auto))
-        ->toBe([
-            'tool' => [
-                'auto' => [],
-            ],
+        ->toEqual([
+            'auto' => new \stdClass,
         ]);
 });


### PR DESCRIPTION
## Summary

Both the Anthropic and Converse schema `ToolChoiceMap` classes produce incorrectly formatted `tool_choice` / `toolChoice` values, causing HTTP 400 errors from the Bedrock API when tools are registered on a request.

### Bug 1: Anthropic schema

`ToolChoiceMap::map()` returns bare strings (`"auto"`, `"any"`) but the Bedrock Anthropic Messages API expects objects:

```diff
- "tool_choice": "auto"
+ "tool_choice": { "type": "auto" }
```

**Error:** `HTTP 400: tool_choice: Input should be a valid dictionary or object to extract fields from`

### Bug 2: Converse schema

`ToolChoiceMap::map()` wraps `auto`/`any` under a `tool` key and uses empty arrays instead of objects:

```diff
- "toolChoice": { "tool": { "auto": [] } }
+ "toolChoice": { "auto": {} }
```

**Error:** `HTTP 400: Value at 'toolConfig.toolChoice.tool.name' failed to satisfy constraint: Member must not be null`

## Changes

- **Anthropic `ToolChoiceMap`**: Return `['type' => 'auto']` / `['type' => 'any']` instead of bare strings. Tightened return type from `string|array|null` to `?array`.
- **Converse `ToolChoiceMap`**: Remove incorrect `tool` wrapper, use `new \stdClass` (serializes as `{}`) instead of `[]` (serializes as `[]`).
- Added Anthropic `ToolChoiceMap` test coverage (5 tests).
- Updated Converse `ToolChoiceMap` tests to assert correct format.

## References

- [Bedrock Converse API — ToolChoice](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html)
- [Bedrock Anthropic Messages API — tool_choice](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html)

## Test plan

- [x] All 8 ToolChoiceMap unit tests pass
- [x] Verified against live Bedrock API with `ToolChoice::Auto` and `ToolChoice::Any`