### PR TITLE
Allow Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "laravel/framework": "^11.0|^12.0",
+    "laravel/framework": "^11.0|^12.0|^13.0",
     "aws/aws-sdk-php": "^3.339",
     "prism-php/prism": ">=0.99.7"
   },


### PR DESCRIPTION
Bedrock has no runtime dependency that requires Laravel <= 12, but the `laravel/framework` constraint stops it installing on Laravel 13.

This widens the constraint to `^11.0|^12.0|^13.0`. No code changes are needed — Bedrock works on Laravel 13 as-is (verified against an app running Laravel 13.14 + prism-php/prism 0.100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)